### PR TITLE
Send and compare bundle ETAG

### DIFF
--- a/src/door_commander/settings.py
+++ b/src/door_commander/settings.py
@@ -93,8 +93,7 @@ LOGGING = json.loads(_DJANGO_LOGGING) if _DJANGO_LOGGING else {
         },
         # Don't show OPA sidecar activity when debugging
         'opa_bundles.views': {
-            'level': 'WARNING',
-            'handlers': ['console'],
+            'level': 'DEBUG',
         }
     },
 }


### PR DESCRIPTION
Send etag with bundle file. tarfile is not binary reproducible, thus the hashes of the files included are used to generate an etag hash.